### PR TITLE
Update eddl/pyeddl recipes

### DIFF
--- a/cpu/Makefile
+++ b/cpu/Makefile
@@ -18,7 +18,7 @@ pyeddl-conda-test: Dockerfile.pyeddl-test pyeddl-conda
 	docker build -t pyeddl-conda-test -f Dockerfile.pyeddl-test .
 
 pyeddl-conda-test-cloud: Dockerfile.pyeddl-test-cloud
-	${SHELL} -c 'rm -rf tests && cp -rf ../../tests .'
+	${SHELL} add_pyeddl_to_repo.sh
 	docker build -t pyeddl-conda-test-cloud -f Dockerfile.pyeddl-test-cloud .
 
 test-eddl: eddl-conda-test

--- a/cpu/eddl/meta.yaml
+++ b/cpu/eddl/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "eddl-cpu" %}
-{% set version = "0.6.0" %}
-{% set sha256 = "a13aba429d2ea110fba66d4f756b59aff1f32480ad260f08db8baa0d40ae25be" %}
+{% set version = "0.7.1" %}
+{% set sha256 = "d454dd71b9045ab3cf9b98e415fe871757b3c72eba24bfe6cfe574d5c078e85c" %}
 
 package:
   name: {{ name|lower }}
@@ -21,7 +21,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - eigen >=3.3.7
+    - eigen >=3.3.7,<3.3.8
     - zlib 1.2*
     - protobuf 3.11*
   run:

--- a/cpu/pyeddl/meta.yaml
+++ b/cpu/pyeddl/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyeddl-cpu" %}
-{% set version = "0.8.0" %}
-{% set sha256 = "a6162612c5c9b870c24b583ca1b90ee2a8275d6d301dca4a8107c3790968dfd5" %}
+{% set version = "0.9.0" %}
+{% set sha256 = "e0c7de901a78270d433be8843505179138941100dfa9de35bfb581c4fce8a4e1" %}
 
 package:
   name: {{ name|lower }}
@@ -18,15 +18,15 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - eddl-cpu ==0.6.0
-    - eigen >=3.3.7
+    - eddl-cpu ==0.7.1
+    - eigen >=3.3.7,<3.3.8
     - numpy
     - pip
-    - pybind11
+    - pybind11 <2.6
     - python {{ py_ver }}
     - setuptools
   run:
-    - eddl-cpu ==0.6.0
+    - eddl-cpu ==0.7.1
     - numpy
     - python {{ py_ver }}
 

--- a/gpu/Makefile
+++ b/gpu/Makefile
@@ -19,7 +19,7 @@ pyeddl-conda-test: Dockerfile.pyeddl-test pyeddl-conda
 	docker build -t pyeddl-conda-test -f Dockerfile.pyeddl-test .
 
 pyeddl-conda-test-cloud: Dockerfile.pyeddl-test-cloud
-	${SHELL} -c 'rm -rf tests && cp -rf ../../tests .'
+	${SHELL} add_pyeddl_to_repo.sh
 	docker build -t pyeddl-conda-test-cloud -f Dockerfile.pyeddl-test-cloud .
 
 test-eddl: eddl-conda-test

--- a/gpu/eddl/conda_build_config.yaml
+++ b/gpu/eddl/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler_version:   # [unix]
+  - 7                 # [linux64]
+cxx_compiler_version: # [unix]
+  - 7                 # [linux64]

--- a/gpu/eddl/meta.yaml
+++ b/gpu/eddl/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "eddl-gpu" %}
-{% set version = "0.6.0" %}
-{% set sha256 = "a13aba429d2ea110fba66d4f756b59aff1f32480ad260f08db8baa0d40ae25be" %}
+{% set version = "0.7.1" %}
+{% set sha256 = "d454dd71b9045ab3cf9b98e415fe871757b3c72eba24bfe6cfe574d5c078e85c" %}
 
 package:
   name: {{ name|lower }}
@@ -17,12 +17,12 @@ build:
 requirements:
   build:
     - make
-    - cmake
+    - cmake <3.18
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - cudatoolkit-dev 10.1*
-    - eigen >=3.3.7
+    - eigen >=3.3.7,<3.3.8
     - zlib 1.2*
     - protobuf 3.11*
   run:

--- a/gpu/pyeddl/conda_build_config.yaml
+++ b/gpu/pyeddl/conda_build_config.yaml
@@ -1,3 +1,7 @@
+c_compiler_version:   # [unix]
+  - 7                 # [linux64]
+cxx_compiler_version: # [unix]
+  - 7                 # [linux64]
 py_ver:
   - 3.6
   - 3.7

--- a/gpu/pyeddl/meta.yaml
+++ b/gpu/pyeddl/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyeddl-gpu" %}
-{% set version = "0.8.0" %}
-{% set sha256 = "a6162612c5c9b870c24b583ca1b90ee2a8275d6d301dca4a8107c3790968dfd5" %}
+{% set version = "0.9.0" %}
+{% set sha256 = "e0c7de901a78270d433be8843505179138941100dfa9de35bfb581c4fce8a4e1" %}
 
 package:
   name: {{ name|lower }}
@@ -19,16 +19,16 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - cudatoolkit 10.1*
-    - eddl-gpu ==0.6.0
-    - eigen >=3.3.7
+    - eddl-gpu ==0.7.1
+    - eigen >=3.3.7,<3.3.8
     - numpy
     - pip
-    - pybind11
+    - pybind11 <2.6
     - python {{ py_ver }}
     - setuptools
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - eddl-gpu ==0.6.0
+    - eddl-gpu ==0.7.1
     - numpy
     - python {{ py_ver }}
 


### PR DESCRIPTION
Updates the EDDL / PyEDDL recipes to EDDL 0.7.1 / PyEDDL 0.9.0.

Note that a constraint has been added to prevent the installation of the new Eigen 3.3.8, since it breaks EDDL compilation according to a heads up by @salvacarrion.

Additional changes not related to the new EDDL / PyEDDL versions but required by the availability of new Conda packages:

* Pinned the compiler version to 7 since CUDA (the version we are installing, at least) does not support gcc versions later than 8 (just kept 7 since it was the highest version available when the recipe was first written)
* Added cmake <3.18 since with 3.18 the `-DCMAKE_CUDA_HOST_COMPILER=${CXX}` setting wasn't working and it was breaking the build (`gcc: No such file or directory` in the program that CMake builds on the fly to test that the CUDA compiler is working)