### PR TITLE
Add libnsl to ECVL host section

### DIFF
--- a/cpu/ecvl/meta.yaml
+++ b/cpu/ecvl/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - dcmtk ==3.6.5
     - eddl-cpu ==1.0.3b
     - python {{ py_ver }}
+    - libnsl
   run:
     - py-opencv <4
     - yaml-cpp ==0.6.3

--- a/cudnn/ecvl/meta.yaml
+++ b/cudnn/ecvl/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - dcmtk ==3.6.5
     - eddl-cudnn ==1.0.3b
     - python {{ py_ver }}
+    - libnsl
   run:
     - cudatoolkit >=10.1,<10.2a0
     - py-opencv <4

--- a/gpu/ecvl/meta.yaml
+++ b/gpu/ecvl/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - dcmtk ==3.6.5
     - eddl-gpu ==1.0.3b
     - python {{ py_ver }}
+    - libnsl
   run:
     - cudatoolkit >=10.1,<10.2a0
     - py-opencv <4


### PR DESCRIPTION
This should hopefully fix the `cannot find -lnsl` link error in the ECVL build